### PR TITLE
Make tests for css-customs-loader more stable by evaluating compiled code

### DIFF
--- a/packages/css-customs-loader/lib/index.js
+++ b/packages/css-customs-loader/lib/index.js
@@ -3,8 +3,9 @@ const postcss = require('postcss')
 const postcssrc = require('postcss-load-config')
 const parsePostcssLoaderOptions = require('postcss-loader/src/options')
 const postcssPresetEnv = require('postcss-preset-env')
+const requireFromString = require('require-from-string')
 const path = require('path')
-const { findNextLoader, isLoader, exec } = require('./utils')
+const { findNextLoader, isLoader } = require('./utils')
 const error = require('./errors')
 
 const rawLoader = require.resolve('raw-loader')
@@ -42,7 +43,7 @@ module.exports = async function(content, sourceMap, meta) {
     css = await new Promise((resolve, reject) => {
       this.loadModule(request, (err, sourceBeforePostcss) => {
         if (err) return reject(err)
-        resolve(exec(sourceBeforePostcss, this.resourcePath, this.context))
+        resolve(requireFromString(sourceBeforePostcss, this.resourcePath))
       })
     })
   } catch (err) {

--- a/packages/css-customs-loader/lib/utils.js
+++ b/packages/css-customs-loader/lib/utils.js
@@ -1,5 +1,3 @@
-const Module = require('module')
-
 const isLoader = (loader, loaderName) =>
   loader.path.match(new RegExp(`\\b${loaderName}\\b`))
 
@@ -13,18 +11,8 @@ const findNextLoader = (self, loaderName) =>
     .slice(self.loaderIndex + 1)
     .find(loader => isLoader(loader, loaderName))
 
-// https://github.com/webpack/webpack.js.org/issues/1268#issuecomment-313513988
-const exec = (code, filename, context) => {
-  const module = new Module(filename, this)
-  module.paths = Module._nodeModulePaths(context)
-  module.filename = filename
-  module._compile(code, filename)
-  return module.exports
-}
-
 module.exports = {
   isLoader,
   findPreviousLoader,
   findNextLoader,
-  exec,
 }

--- a/packages/css-customs-loader/package.json
+++ b/packages/css-customs-loader/package.json
@@ -28,7 +28,8 @@
     "loader-utils": "^1.1.0",
     "postcss": "^7.0.5",
     "postcss-load-config": "^2.0.0",
-    "raw-loader": "^0.5.1"
+    "raw-loader": "^0.5.1",
+    "require-from-string": "^2.0.2"
   },
   "devDependencies": {
     "css-loader": "^3.2.0",

--- a/packages/css-customs-loader/test/__snapshots__/index.test.js.snap
+++ b/packages/css-customs-loader/test/__snapshots__/index.test.js.snap
@@ -1,23 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`can export only locals 1`] = `
-"// Exports
-module.exports = {
-	\\"text\\": \\"_3KySKA6rf07sl0ilq7bBBm\\"
-};
-
-module.exports = module.exports || {};
-module.exports[\\"customMedia\\"] = {
-  \\"--narrow-window\\": \\"(max-width: 30em)\\"
-};
-module.exports[\\"customProperties\\"] = {
-  \\"--primary-color\\": \\"lightblue\\"
-};
-module.exports[\\"customSelectors\\"] = {
-  \\":--title\\": \\"h1\\"
-};"
-`;
-
 exports[`emits an error when css-customs-loader is placed after css-loader 1`] = `
 "./fixtures/basic.css
 Module build failed (from ../index.js):
@@ -60,68 +42,4 @@ postcss-preset-env is missing from your plugins, you need to use it in order for
     at Runtime._loadModule (<CWD>/node_modules/jest-runtime/build/index.js:678:12)
     at Runtime.requireModule (<CWD>/node_modules/jest-runtime/build/index.js:536:10)
     at Runtime.requireModuleOrMock (<CWD>/node_modules/jest-runtime/build/index.js:699:21)"
-`;
-
-exports[`exposes CSS Modules in the same object as customs 1`] = `
-"exports = module.exports = require(\\"<relative path to CWD>/node_modules/css-loader/dist/runtime/api.js\\")(false);
-// Module
-exports.push([module.id, \\":root {\\\\n  --primary-color: lightblue;\\\\n}\\\\n\\\\n._3KySKA6rf07sl0ilq7bBBm {\\\\n  color: lightblue;\\\\n  color: var(--primary-color);\\\\n}\\\\n\\", \\"\\"]);
-// Exports
-exports.locals = {
-	\\"text\\": \\"_3KySKA6rf07sl0ilq7bBBm\\"
-};
-
-exports.locals = exports.locals || {};
-exports.locals[\\"customMedia\\"] = {
-  \\"--narrow-window\\": \\"(max-width: 30em)\\"
-};
-exports.locals[\\"customProperties\\"] = {
-  \\"--primary-color\\": \\"lightblue\\"
-};
-exports.locals[\\"customSelectors\\"] = {
-  \\":--title\\": \\"h1\\"
-};"
-`;
-
-exports[`exposes CSS customs in the default export object 1`] = `
-"exports = module.exports = require(\\"<relative path to CWD>/node_modules/css-loader/dist/runtime/api.js\\")(false);
-// Module
-exports.push([module.id, \\":root {\\\\n  --primary-color: lightblue;\\\\n}\\\\n\\", \\"\\"]);
-
-exports.locals = exports.locals || {};
-exports.locals[\\"customMedia\\"] = {
-  \\"--narrow-window\\": \\"(max-width: 30em)\\"
-};
-exports.locals[\\"customProperties\\"] = {
-  \\"--primary-color\\": \\"lightblue\\"
-};
-exports.locals[\\"customSelectors\\"] = {
-  \\":--title\\": \\"h1\\"
-};"
-`;
-
-exports[`uses PostCSS plugins before postcss-preset-env 1`] = `
-"exports = module.exports = require(\\"<relative path to CWD>/node_modules/css-loader/dist/runtime/api.js\\")(false);
-// Module
-exports.push([module.id, \\":root {\\\\n  --primary-color: #1da1f2;\\\\n}\\\\n\\", \\"\\"]);
-
-exports.locals = exports.locals || {};
-exports.locals[\\"customMedia\\"] = {};
-exports.locals[\\"customProperties\\"] = {
-  \\"--primary-color\\": \\"#1da1f2\\"
-};
-exports.locals[\\"customSelectors\\"] = {};"
-`;
-
-exports[`uses webpack loaders after postcss-loader 1`] = `
-"exports = module.exports = require(\\"<relative path to CWD>/node_modules/css-loader/dist/runtime/api.js\\")(false);
-// Module
-exports.push([module.id, \\":root {\\\\n  --primary-color: lightblue;\\\\n}\\\\n.text {\\\\n  color: lightblue;\\\\n  color: var(--primary-color);\\\\n}\\\\n\\", \\"\\"]);
-
-exports.locals = exports.locals || {};
-exports.locals[\\"customMedia\\"] = {};
-exports.locals[\\"customProperties\\"] = {
-  \\"--primary-color\\": \\"lightblue\\"
-};
-exports.locals[\\"customSelectors\\"] = {};"
 `;

--- a/packages/css-customs-loader/test/__snapshots__/index.test.js.snap
+++ b/packages/css-customs-loader/test/__snapshots__/index.test.js.snap
@@ -23,7 +23,7 @@ exports[`emits an error when css-customs-loader is placed after css-loader 1`] =
 Module build failed (from ../index.js):
 Error: css-customs-loader should be added BEFORE css-loader. <CWD>/node_modules/css-loader/dist/cjs.js??ref--4-0!<CWD>/packages/css-customs-loader/index.js!<CWD>/node_modules/postcss-loader/src/index.js!<CWD>/packages/css-customs-loader/test/fixtures/basic.css
     at Object.exports.addBeforeCssLoader (<CWD>/packages/css-customs-loader/lib/errors.js:2:3)
-    at Object.addBeforeCssLoader (<CWD>/packages/css-customs-loader/lib/index.js:20:27)"
+    at Object.addBeforeCssLoader (<CWD>/packages/css-customs-loader/lib/index.js:21:27)"
 `;
 
 exports[`emits an error when postcss-loader is missing 1`] = `
@@ -37,7 +37,7 @@ postcss-loader is missing, you need to use it in order for css-customs-loader to
     at Runtime._loadModule (<CWD>/node_modules/jest-runtime/build/index.js:678:12)
     at Runtime.requireModule (<CWD>/node_modules/jest-runtime/build/index.js:536:10)
     at Runtime.requireModuleOrMock (<CWD>/node_modules/jest-runtime/build/index.js:699:21)
-    at Object.require (<CWD>/packages/css-customs-loader/lib/index.js:8:15)
+    at Object.require (<CWD>/packages/css-customs-loader/lib/index.js:9:15)
     at Runtime._execModule (<CWD>/node_modules/jest-runtime/build/index.js:1034:22)
     at Runtime._loadModule (<CWD>/node_modules/jest-runtime/build/index.js:678:12)
     at Runtime.requireModule (<CWD>/node_modules/jest-runtime/build/index.js:536:10)
@@ -55,7 +55,7 @@ postcss-preset-env is missing from your plugins, you need to use it in order for
     at Runtime._loadModule (<CWD>/node_modules/jest-runtime/build/index.js:678:12)
     at Runtime.requireModule (<CWD>/node_modules/jest-runtime/build/index.js:536:10)
     at Runtime.requireModuleOrMock (<CWD>/node_modules/jest-runtime/build/index.js:699:21)
-    at Object.require (<CWD>/packages/css-customs-loader/lib/index.js:8:15)
+    at Object.require (<CWD>/packages/css-customs-loader/lib/index.js:9:15)
     at Runtime._execModule (<CWD>/node_modules/jest-runtime/build/index.js:1034:22)
     at Runtime._loadModule (<CWD>/node_modules/jest-runtime/build/index.js:678:12)
     at Runtime.requireModule (<CWD>/node_modules/jest-runtime/build/index.js:536:10)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9522,6 +9522,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"


### PR DESCRIPTION
The details of the compiled code can change across different versions of webpack loaders, but the exported locals should stay the same, so now we're only checking for that.